### PR TITLE
Remove repository tags after pushing.

### DIFF
--- a/docker-pushmi-pullyu
+++ b/docker-pushmi-pullyu
@@ -48,5 +48,6 @@ docker rmi "$registry_host:$registry_port/$image_name"
 echo "Pulling $image_name onto $deploy_target from $registry_host:$registry_port..."
 ssh -R "$registry_port:$registry_host:$registry_port" "$deploy_target" $ssh_arguments sh <<EOF
   docker pull "$registry_host:$registry_port/$image_name" \
-    && docker tag "$registry_host:$registry_port/$image_name" "$image_name"
+    && docker tag "$registry_host:$registry_port/$image_name" "$image_name" \
+    && docker rmi "$registry_host:$registry_port/$image_name"
 EOF

--- a/docker-pushmi-pullyu
+++ b/docker-pushmi-pullyu
@@ -42,6 +42,7 @@ registry_container_name=$(
 echo "Pushing $image_name to $registry_host:$registry_port..."
 docker tag "$image_name" "$registry_host:$registry_port/$image_name"
 docker push "$registry_host:$registry_port/$image_name"
+docker rmi "$registry_host:$registry_port/$image_name"
 
 echo "Pulling $image_name onto $deploy_target from $registry_host:$registry_port..."
 ssh -R "$registry_port:$registry_host:$registry_port" "$deploy_target" sh <<EOF


### PR DESCRIPTION
Cleans up the `localhost:5000/*` tag used for the push on both the local and remote hosts.

Replaces #10.