### PR TITLE
Push multiple images at once.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Docker Pushmi-Pullyu
 
-A script to copy a Docker image directly to a remote host without using Docker 
+A script to copy Docker images directly to a remote host without using Docker
 Hub or a hosted registry.
 
-The implementation pushes the image to a temporary local registry then pulls 
-it to the remote host through an SSH tunnel. This takes advantage of Docker's 
+The implementation pushes images to a temporary local registry then pulls them
+to the remote host through an SSH tunnel. This takes advantage of Docker's
 layer-based cache to avoid superfluous network I/O.
 
 ![Dr. Dolittle's pushmi-pullyu](pushmi-pullyu.png)

--- a/docker-pushmi-pullyu
+++ b/docker-pushmi-pullyu
@@ -32,7 +32,7 @@ usage() {
   echo "
 Usage:	$0 [OPTIONS] [USER@]HOST NAME[:TAG] [ NAME[:TAG] ... ]
 
-Push an images directly to a remote host (without a separate registry)
+Push images directly to a remote host (without a separate registry)
 
 Options:
   -s, --ssh_opts string   Specify additional ssh arguments (e.g. --ssh_opts \"-i private.pem -C\")"

--- a/docker-pushmi-pullyu
+++ b/docker-pushmi-pullyu
@@ -30,9 +30,9 @@ argument_error() {
 
 usage() {
   echo "
-Usage:	$0 [OPTIONS] NAME[:TAG] [USER@]HOST
+Usage:	$0 [OPTIONS] [USER@]HOST NAME[:TAG] [ NAME[:TAG] ... ]
 
-Push an image directly to a remote host (without a separate registry)
+Push an images directly to a remote host (without a separate registry)
 
 Options:
   -s, --ssh_opts string   Specify additional ssh arguments (e.g. --ssh_opts \"-i private.pem -C\")"
@@ -71,13 +71,14 @@ done
 
 eval set -- "$args"
 
-if [ "$#" -ne 2 ]
+if [ "$#" -lt 2 ]
 then
-  argument_error "\"$0\" requires exactly 2 arguments."
+  argument_error "\"$0\" requires at least 2 arguments."
 fi
 
-image_name="$1"
-deploy_target="$2"
+deploy_target="$1"
+shift
+image_names="$*"
 
 registry_port=5000
 registry_host="localhost"
@@ -87,14 +88,19 @@ registry_container_name=$(
   docker run --detach --publish="$registry_port:$registry_port" registry:2
 )
 
-echo "Pushing $image_name to $registry_host:$registry_port..."
-docker tag "$image_name" "$registry_host:$registry_port/$image_name"
-docker push "$registry_host:$registry_port/$image_name"
-docker rmi "$registry_host:$registry_port/$image_name"
+for image_name in $image_names; do
+  echo "Pushing $image_name to $registry_host:$registry_port..."
+  docker tag "$image_name" "$registry_host:$registry_port/$image_name"
+  docker push "$registry_host:$registry_port/$image_name"
+  docker rmi "$registry_host:$registry_port/$image_name"
+done
 
-echo "Pulling $image_name onto $deploy_target from $registry_host:$registry_port..."
+echo "Pulling $image_names onto $deploy_target from $registry_host:$registry_port..."
+
 ssh -R "$registry_port:$registry_host:$registry_port" ${ssh_opts:-} "$deploy_target" sh <<EOF
-  docker pull "$registry_host:$registry_port/$image_name" \
-    && docker tag "$registry_host:$registry_port/$image_name" "$image_name" \
-    && docker rmi "$registry_host:$registry_port/$image_name"
+  for image_name in $image_names; do
+    docker pull "$registry_host:$registry_port/$image_name" \
+      && docker tag "$registry_host:$registry_port/$image_name" "$image_name" \
+      && docker rmi "$registry_host:$registry_port/$image_name"
+  done
 EOF

--- a/docker-pushmi-pullyu
+++ b/docker-pushmi-pullyu
@@ -88,19 +88,18 @@ registry_container_name=$(
   docker run --detach --publish="$registry_port:$registry_port" registry:2
 )
 
-for image_name in $image_names; do
-  echo "Pushing $image_name to $registry_host:$registry_port..."
-  docker tag "$image_name" "$registry_host:$registry_port/$image_name"
-  docker push "$registry_host:$registry_port/$image_name"
-  docker rmi "$registry_host:$registry_port/$image_name"
+for source_image_name in $image_names; do
+  echo "Pushing $source_image_name to $registry_host:$registry_port..."
+  docker tag "$source_image_name" "$registry_host:$registry_port/$source_image_name"
+  docker push "$registry_host:$registry_port/$source_image_name"
+  docker rmi "$registry_host:$registry_port/$source_image_name"
 done
 
-echo "Pulling $image_names onto $deploy_target from $registry_host:$registry_port..."
-
 ssh -R "$registry_port:$registry_host:$registry_port" ${ssh_opts:-} "$deploy_target" sh <<EOF
-  for image_name in $image_names; do
-    docker pull "$registry_host:$registry_port/$image_name" \
-      && docker tag "$registry_host:$registry_port/$image_name" "$image_name" \
-      && docker rmi "$registry_host:$registry_port/$image_name"
+  for target_image_name in $image_names; do
+    echo "Pulling \$target_image_name onto $deploy_target from $registry_host:$registry_port..."
+    docker pull "$registry_host:$registry_port/\$target_image_name" \
+      && docker tag "$registry_host:$registry_port/\$target_image_name" "\$target_image_name" \
+      && docker rmi "$registry_host:$registry_port/\$target_image_name"
   done
 EOF

--- a/docker-pushmi-pullyu
+++ b/docker-pushmi-pullyu
@@ -30,7 +30,7 @@ argument_error() {
 
 usage() {
   echo "
-Usage:	$0 [OPTIONS] [USER@]HOST NAME[:TAG] [ NAME[:TAG] ... ]
+Usage:	$0 [OPTIONS] [USER@]HOST NAME[:TAG] [NAME[:TAG]...]
 
 Push images directly to a remote host (without a separate registry)
 
@@ -88,7 +88,8 @@ registry_container_name=$(
   docker run --detach --publish="$registry_port:$registry_port" registry:2
 )
 
-for source_image_name in $image_names; do
+for source_image_name in $image_names
+do
   echo "Pushing $source_image_name to $registry_host:$registry_port..."
   docker tag "$source_image_name" "$registry_host:$registry_port/$source_image_name"
   docker push "$registry_host:$registry_port/$source_image_name"
@@ -96,7 +97,8 @@ for source_image_name in $image_names; do
 done
 
 ssh -R "$registry_port:$registry_host:$registry_port" ${ssh_opts:-} "$deploy_target" sh <<EOF
-  for target_image_name in $image_names; do
+  for target_image_name in $image_names
+  do
     echo "Pulling \$target_image_name onto $deploy_target from $registry_host:$registry_port..."
     docker pull "$registry_host:$registry_port/\$target_image_name" \
       && docker tag "$registry_host:$registry_port/\$target_image_name" "\$target_image_name" \


### PR DESCRIPTION
* Changes the order of command line arguments to HOST first and then n images (breaks cli compatibility)
* Pushes multiple images into the registry and then pulls those images on the remote before destroying the registry.

Replaces #18.