### PR TITLE
lint with shellcheck

### DIFF
--- a/docker-pushmi-pullyu
+++ b/docker-pushmi-pullyu
@@ -50,7 +50,7 @@ wait-for() {
     # option is set.
     "$@" && exit_code="$?" || exit_code="$?"
 
-    if [ "$exit_code" -eq 0 ] || [ $(($SECONDS - $start_time)) -ge "$max_wait_seconds" ]
+    if [ "$exit_code" -eq 0 ] || [ "$($SECONDS - $start_time)" -ge "$max_wait_seconds" ]
     then
       break
     else
@@ -128,7 +128,7 @@ do
   docker rmi "$registry_host:$registry_port/$source_image_name"
 done
 
-ssh -R "$registry_port:$registry_host:$registry_port" ${ssh_opts:-} "$deploy_target" sh <<EOF
+ssh -R "$registry_port:$registry_host:$registry_port" ${ssh_opts:-} "$deploy_target" sh <<"EOF"
   for target_image_name in $image_names
   do
     echo "Pulling \$target_image_name onto $deploy_target from $registry_host:$registry_port..."

--- a/docker-pushmi-pullyu
+++ b/docker-pushmi-pullyu
@@ -128,7 +128,8 @@ do
   docker rmi "$registry_host:$registry_port/$source_image_name"
 done
 
-ssh -R "$registry_port:$registry_host:$registry_port" ${ssh_opts:-} "$deploy_target" sh <<"EOF"
+# shellcheck disable=SC2087
+ssh -R "$registry_port:$registry_host:$registry_port" ${ssh_opts:-} "$deploy_target" sh <<EOF
   for target_image_name in $image_names
   do
     echo "Pulling \$target_image_name onto $deploy_target from $registry_host:$registry_port..."


### PR DESCRIPTION
I use this marvelous script all the time to run my personal infrastructure.

I linted it with Shellcheck and it recommended two small changes:

$/${} is unnecessary on arithmetic variables.
     https://github.com/koalaman/shellcheck/wiki/SC2004

Quote 'EOF' to make here document expansions happen on the server side rather than on the client.
    https://github.com/koalaman/shellcheck/wiki/SC2087