### PR TITLE
Disable another not-applicable shellcheck warning.

### DIFF
--- a/docker-pushmi-pullyu
+++ b/docker-pushmi-pullyu
@@ -150,7 +150,7 @@ do
   docker rmi "$registry_host:$registry_port/$source_image_name"
 done
 
-# shellcheck disable=SC2087
+# shellcheck disable=SC2086,SC2087
 ssh -R "$registry_port:$registry_host:$registry_port" ${ssh_opts:-} "$deploy_target" sh <<EOF
   for target_image_name in $image_names
   do


### PR DESCRIPTION
[SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086) was complaining about `${ssh_opts:-}` being unqouted ("Double quote to prevent globbing and word splitting"), but we specifically want word splitting here.