### PR TITLE
Fix unexpected dual-stack port binding

### DIFF
--- a/docker-pushmi-pullyu
+++ b/docker-pushmi-pullyu
@@ -126,7 +126,7 @@ then
     docker run \
       --detach \
       --volume="docker-pushmi-pullyu:/var/lib/registry" \
-      --publish 127.0.0.1::5000 \
+      --publish 0.0.0.0::5000 \
       registry:2
   )
 else
@@ -134,14 +134,14 @@ else
   registry_container_name=$(
     docker run \
       --detach \
-      --publish 127.0.0.1::5000 \
+      --publish 0.0.0.0::5000 \
       registry:2
   )
 fi
 
 registry_port=$(
   registry_location=$(docker port "$registry_container_name" 5000)
-  echo "${registry_location##127.0.0.1:}"
+  echo "${registry_location##0.0.0.0:}"
 )
 
 wait-for check-registry "$registry_host:$registry_port"

--- a/docker-pushmi-pullyu
+++ b/docker-pushmi-pullyu
@@ -126,7 +126,7 @@ then
     docker run \
       --detach \
       --volume="docker-pushmi-pullyu:/var/lib/registry" \
-      --publish-all \
+      --publish 127.0.0.1::5000 \
       registry:2
   )
 else
@@ -134,14 +134,14 @@ else
   registry_container_name=$(
     docker run \
       --detach \
-      --publish-all \
+      --publish 127.0.0.1::5000 \
       registry:2
   )
 fi
 
 registry_port=$(
   registry_location=$(docker port "$registry_container_name" 5000)
-  echo "${registry_location##0.0.0.0:}"
+  echo "${registry_location##127.0.0.1:}"
 )
 
 wait-for check-registry "$registry_host:$registry_port"


### PR DESCRIPTION
Publishing all ports results into two port bindings (1 for IPv4
and 1 for IPv6).

However, the script expected `docker port` to return only 1 port.

Docker version:
```
Client:
 Version:           20.10.13
 API version:       1.41
 Go version:        go1.17.8
 Git commit:        a224086349
 Built:             Sat Mar 12 14:11:41 2022
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true

Server:
 Engine:
  Version:          20.10.13
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.17.8
  Git commit:       906f57ff5b
  Built:            Sat Mar 12 14:10:25 2022
  OS/Arch:          linux/amd64
  Experimental:     true
 containerd:
  Version:          v1.6.1
  GitCommit:        10f428dac7cec44c864e1b830a4623af27a9fc70.m
 runc:
  Version:          1.1.0
  GitCommit:        v1.1.0-0-g067aaf85
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

Output of `docker port` with `--publish-all`:
```
5000/tcp -> 0.0.0.0:49286
5000/tcp -> :::49286
```